### PR TITLE
Make optional transport option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ internals.defaults = {
 
 
 internals.schema = Joi.object({
-    transport: Joi.object().required(),
+    transport: Joi.object(),
     views: Joi.object()
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-mailer",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Mailer plugin for hapi.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In the Readme, there is written _If `transport` is not set `nodemailer-direct-transport` transport is used_. 
With the current Joi validation, `transport` is required and has to be an object and setting it to an empty object `{}` does not set nodemailer to `nodemailer-direct-transport`.
So, currently there is no way to register the plugin and set `nodemailer-direct-transport` transport.
With this pull request, one can pass plugin options without `transport` key, thus setting `nodemailer-direct-transport`.